### PR TITLE
Hotfix - unable to delete message

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -61,7 +61,7 @@ AddEventHandler("Telegram:DeleteMessage", function(id)
 		if count > 0 then 
 			TriggerEvent("Telegram:GetMessages", _source)
 		else
-			TriggerClientEvent('QBCore:Notify', _source, Lang:t('telegrm.unable_to_delete'), 'error')
+			TriggerClientEvent('QBCore:Notify', _source, Lang:t('telegram.unable_to_delete'), 'error')
 		end
 	end)
 end)


### PR DESCRIPTION
Hotfix - unable to delete message
A little mistake. It was telegrm instead of telegram